### PR TITLE
Add folder model

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+if ! command -v yarn >/dev/null 2>&1; then
+  echo "Error: yarn is not installed. Please install it before running this script." >&2
+  exit 1
+fi
+
+yarn install --frozen-lockfile
+
+echo "All dependencies installed successfully."

--- a/server/migrations/20250418000000-create-folders.js
+++ b/server/migrations/20250418000000-create-folders.js
@@ -1,0 +1,95 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.createTable(
+        "folders",
+        {
+          id: {
+            type: Sequelize.UUID,
+            allowNull: false,
+            primaryKey: true,
+          },
+          title: {
+            type: Sequelize.STRING,
+            allowNull: false,
+          },
+          urlId: {
+            type: Sequelize.STRING(10),
+            allowNull: false,
+            unique: true,
+          },
+          parentFolderId: {
+            type: Sequelize.UUID,
+            allowNull: true,
+            onDelete: "cascade",
+            references: {
+              model: "folders",
+              key: "id",
+            },
+          },
+          collectionId: {
+            type: Sequelize.UUID,
+            allowNull: false,
+            onDelete: "cascade",
+            references: {
+              model: "collections",
+              key: "id",
+            },
+          },
+          teamId: {
+            type: Sequelize.UUID,
+            allowNull: false,
+            onDelete: "cascade",
+            references: {
+              model: "teams",
+              key: "id",
+            },
+          },
+          createdById: {
+            type: Sequelize.UUID,
+            allowNull: false,
+            onDelete: "cascade",
+            references: {
+              model: "users",
+              key: "id",
+            },
+          },
+          updatedById: {
+            type: Sequelize.UUID,
+            allowNull: false,
+            onDelete: "cascade",
+            references: {
+              model: "users",
+              key: "id",
+            },
+          },
+          createdAt: {
+            type: Sequelize.DATE,
+            allowNull: false,
+          },
+          updatedAt: {
+            type: Sequelize.DATE,
+            allowNull: false,
+          },
+          deletedAt: {
+            type: Sequelize.DATE,
+            allowNull: true,
+          },
+        },
+        { transaction }
+      );
+
+      await queryInterface.addIndex("folders", ["collectionId"], { transaction });
+      await queryInterface.addIndex("folders", ["parentFolderId"], { transaction });
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.dropTable("folders", { transaction });
+    });
+  },
+};

--- a/server/models/Folder.ts
+++ b/server/models/Folder.ts
@@ -1,0 +1,117 @@
+import {
+  Table,
+  Column,
+  DataType,
+  DefaultScope,
+  ForeignKey,
+  BelongsTo,
+  IsUUID,
+  Unique,
+  HasMany,
+} from "sequelize-typescript";
+import { InferAttributes, InferCreationAttributes, FindOptions } from "sequelize";
+import slugify from "@shared/utils/slugify";
+import { NavigationNode, NavigationNodeType } from "@shared/types";
+import { generateUrlId } from "@server/utils/url";
+import ParanoidModel from "./base/ParanoidModel";
+import Collection from "./Collection";
+import Team from "./Team";
+import User from "./User";
+
+@DefaultScope(() => ({
+  where: {
+    deletedAt: null,
+  },
+}))
+@Table({ tableName: "folders", modelName: "folder" })
+class Folder extends ParanoidModel<
+  InferAttributes<Folder>,
+  InferCreationAttributes<Folder>
+> {
+  @Column
+  title: string;
+
+  @Unique
+  @Column
+  urlId: string;
+
+  @IsUUID(4)
+  @ForeignKey(() => Folder)
+  @Column(DataType.UUID)
+  parentFolderId?: string | null;
+
+  @BelongsTo(() => Folder, "parentFolderId")
+  parentFolder?: Folder | null;
+
+  @HasMany(() => Folder, "parentFolderId")
+  children?: Folder[];
+
+  @IsUUID(4)
+  @ForeignKey(() => Collection)
+  @Column(DataType.UUID)
+  collectionId!: string;
+
+  @BelongsTo(() => Collection)
+  collection!: Collection;
+
+  @IsUUID(4)
+  @ForeignKey(() => Team)
+  @Column(DataType.UUID)
+  teamId!: string;
+
+  @BelongsTo(() => Team)
+  team!: Team;
+
+  @IsUUID(4)
+  @ForeignKey(() => User)
+  @Column(DataType.UUID)
+  createdById!: string;
+
+  @BelongsTo(() => User, "createdById")
+  createdBy!: User;
+
+  @IsUUID(4)
+  @ForeignKey(() => User)
+  @Column(DataType.UUID)
+  updatedById!: string;
+
+  @BelongsTo(() => User, "updatedById")
+  updatedBy!: User;
+
+  get url() {
+    return Folder.getPath({ title: this.title, urlId: this.urlId });
+  }
+
+  static getPath({ title, urlId }: { title: string; urlId: string }) {
+    const slugifiedTitle = slugify(title);
+    if (!slugifiedTitle) {
+      return `/folder/untitled-${urlId}`;
+    }
+    return `/folder/${slugifiedTitle}-${urlId}`;
+  }
+
+  static beforeCreate(folder: Folder) {
+    folder.urlId = folder.urlId || generateUrlId();
+  }
+
+  async toNavigationNode(options?: FindOptions<Folder>): Promise<NavigationNode> {
+    const childFolders = await (this.constructor as typeof Folder).findAll({
+      where: { parentFolderId: this.id },
+      transaction: options?.transaction,
+    });
+
+    const children = await Promise.all(
+      childFolders.map((child) => child.toNavigationNode(options))
+    );
+
+    return {
+      id: this.id,
+      title: this.title,
+      url: this.url,
+      children,
+      type: NavigationNodeType.Folder,
+    };
+  }
+}
+
+export default Folder;

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -67,3 +67,4 @@ export { default as WebhookSubscription } from "./WebhookSubscription";
 export { default as WebhookDelivery } from "./WebhookDelivery";
 
 export { default as Subscription } from "./Subscription";
+export { default as Folder } from "./Folder";

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -305,6 +305,7 @@ export type TeamPreferences = {
 export enum NavigationNodeType {
   Collection = "collection",
   Document = "document",
+  Folder = "folder",
   UserMembership = "userMembership",
   GroupMembership = "groupMembership",
 }


### PR DESCRIPTION
## Summary
- add scripts/setup.sh for yarn-based initialization
- create Folder model with navigation node support
- create migration to add folders table
- expose Folder from server models
- support Folder node type in shared types

## Testing
- `yarn lint` *(fails: The engine "node" is incompatible)*
- `yarn test` *(fails: The engine "node" is incompatible)*